### PR TITLE
Modernize layout and correct CVR/SVR assembly

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,38 +1,25 @@
-.App {
-  text-align: center;
-}
-
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
+/* Modern layout styling */
+.app-container {
   display: flex;
-  flex-direction: column;
-  align-items: center;
+  flex-direction: row;
+  min-height: 100vh;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.viewer-container {
+  flex: 1;
+  display: flex;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
+  align-items: center;
+  background: #e9ecef;
+  padding: 20px;
 }
 
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.viewer-canvas {
+  width: 100%;
+  height: 60vh;
+  max-width: 800px;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  background: #fff;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,22 +1,26 @@
-import React, { useState } from "react";
+import React, { useState, Suspense, lazy } from "react";
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";
 import DarkModeToggle from "./components/DarkModeToggle";
-import Door from "./components/Door";
-import Rail from "./components/Rail";
-import ETTrim from "./components/ETTrim";
-import Screws from "./components/Screws";
-import SquareSpindle from "./components/SquareSpindle";
-import CrossSpindle from "./components/CrossSpindle";
-import Chassis from "./components/Chassis";
-import Cover from "./components/Cover";
-import CVRTopCase from "./components/CVRTopCase";
-import SVRTopCase from "./components/SVRTopCase";
-import SVRBottomCase from "./components/SVRBottomCase";
-import CVRRods from "./components/CVRRods";
-import SVRRods from "./components/SVRRods";
-import CVRInnerChassis from "./components/CVRInnerChassis";
-import MortiseCase from "./components/MortiseCase";
+import "./App.css";
+
+// Lazy-load heavy 3D components to improve initial load time
+const Door = lazy(() => import("./components/Door"));
+const Rail = lazy(() => import("./components/Rail"));
+const ETTrim = lazy(() => import("./components/ETTrim"));
+const Screws = lazy(() => import("./components/Screws"));
+const SquareSpindle = lazy(() => import("./components/SquareSpindle"));
+const CrossSpindle = lazy(() => import("./components/CrossSpindle"));
+const Chassis = lazy(() => import("./components/Chassis"));
+const Cover = lazy(() => import("./components/Cover"));
+const CVRTopCase = lazy(() => import("./components/CVRTopCase"));
+const CVRBottomCase = lazy(() => import("./components/CVRBottomCase"));
+const SVRTopCase = lazy(() => import("./components/SVRTopCase"));
+const SVRBottomCase = lazy(() => import("./components/SVRBottomCase"));
+const CVRRods = lazy(() => import("./components/CVRRods"));
+const SVRRods = lazy(() => import("./components/SVRRods"));
+const CVRInnerChassis = lazy(() => import("./components/CVRInnerChassis"));
+const MortiseCase = lazy(() => import("./components/MortiseCase"));
 import { thicknessOptions, deviceLists, functionLists } from "./components/thickDoorData";
 
 // Constants for styles
@@ -114,7 +118,7 @@ function App() {
   const zOffset = parseFloat(thickness) / 2;
 
   return (
-    <div style={{ display: "flex", flexDirection: "row", height: "100vh" }}>
+    <div className="app-container" style={{ backgroundColor: isDarkMode ? "#121212" : "#ffffff" }}>
       {/* Hamburger Menu */}
       {!isPanelVisible && (
         <button
@@ -187,33 +191,36 @@ function App() {
       <DarkModeToggle isDarkMode={isDarkMode} setIsDarkMode={(value) => updateState("isDarkMode", value)} />
 
       {/* 3D Canvas */}
-      <div style={{ flex: "1", transition: "all 0.3s ease", paddingLeft: isPanelVisible ? "0" : "20px" }}>
-        <Canvas camera={{ position: [55, 55, 55] }}>
-          <ambientLight intensity={0.5} />
-          <directionalLight position={[54, 10, 5]} intensity={1.5} />
-          <Door hideDoor={visibleObjects["Ghost Door"]} hideFrame={visibleObjects["Ghost Frame"]} thickness={parseFloat(thickness)} />
-          {visibleObjects["Chassis"] && <Chassis position={[15.25, 0, 0.375 + zOffset]} />}
-          {lockType === "Mortise" && visibleObjects["Mortise Case"] && <MortiseCase position={[15.975, 41, 0]} />}
-          {lockType === "CVR" && visibleObjects["Inner Chassis"] && <CVRInnerChassis position={[15.25, 41, 0]} />}
-          {lockType === "CVR" && <CVRTopCase position={[15.25, 82.05, 0 + zOffset]} />}
-          {lockType === "SVR" && <SVRTopCase position={[15.25, 39.7, 0.6 + zOffset]} />}
-          {lockType === "SVR" && <SVRBottomCase position={[15.25, -39, 0.6 + zOffset]} />}
-          {lockType === "CVR" && visibleObjects["Top Rod"] && <CVRRods position={[15.25, 20, 0]} length={36.75} />}
-          {lockType === "CVR" && visibleObjects["Bottom Rod"] && <CVRRods position={[15.25, -22, 0]} length={36} />}
-          {lockType === "SVR" && visibleObjects["Top Rod"] && <SVRRods position={[15.25, 20, 0.5 + zOffset]} length={36.5} />}
-          {lockType === "SVR" && visibleObjects["Bottom Rod"] && <SVRRods position={[15.25, -19, 0.5 + zOffset]} length={36} />}
-          {visibleObjects["Chassis Cover"] && <Cover position={[15.25, 41, 0 + zOffset]} />}
-          {visibleObjects["Rail"] && <Rail position={[0, 0, -1 + zOffset]} scale={[40, 40, 40]} rotations={{ insert: [0, Math.PI / 2, Math.PI / 2], push: [Math.PI / 2, Math.PI / 2, 0], mounting: [0, Math.PI / 2, Math.PI / 2] }} />}
-          {visibleObjects["Trim"] && <ETTrim position={[15.25, 40.7875, 0.03 - zOffset]} />}
-          {visibleObjects["Screws"] && <Screws topPosition={[15.25, 43.5375, 0.025 + zOffset]} bottomPosition={[15.25, 38.45, 0.025 + zOffset]} thickness={parseFloat(thickness)} />}
-          {visibleObjects["Spindle"] && (
-            <>
-              <SquareSpindle position={[15.25, 39.7875, -0.125 - zOffset]} thickness={parseFloat(thickness)} />
-              <CrossSpindle position={[15.25, 39.7875, -0.125 - zOffset]} thickness={parseFloat(thickness)} />
-            </>
-          )}
-          <OrbitControls />
-        </Canvas>
+      <div className="viewer-container" style={{ paddingLeft: isPanelVisible ? "0" : "20px" }}>
+        <Suspense fallback={<div>Loading 3D...</div>}>
+          <Canvas className="viewer-canvas" camera={{ position: [55, 55, 55] }}>
+            <ambientLight intensity={0.5} />
+            <directionalLight position={[54, 10, 5]} intensity={1.5} />
+            <Door hideDoor={visibleObjects["Ghost Door"]} hideFrame={visibleObjects["Ghost Frame"]} thickness={parseFloat(thickness)} />
+            {visibleObjects["Chassis"] && <Chassis position={[15.25, 0, 0.375 + zOffset]} />}
+            {lockType === "Mortise" && visibleObjects["Mortise Case"] && <MortiseCase position={[15.975, 41, 0]} />}
+            {lockType === "CVR" && visibleObjects["Inner Chassis"] && <CVRInnerChassis position={[15.25, 41, 0]} />}
+            {lockType === "CVR" && <CVRTopCase position={[15.25, 82, 0 + zOffset]} />}
+            {lockType === "CVR" && <CVRBottomCase position={[15.25, 2, 0 + zOffset]} />}
+            {lockType === "SVR" && <SVRTopCase position={[15.25, 82, 0.6 + zOffset]} />}
+            {lockType === "SVR" && <SVRBottomCase position={[15.25, 2, 0.6 + zOffset]} />}
+            {lockType === "CVR" && visibleObjects["Top Rod"] && <CVRRods position={[15.25, 61.5, 0]} length={41} />}
+            {lockType === "CVR" && visibleObjects["Bottom Rod"] && <CVRRods position={[15.25, 21.5, 0]} length={39} />}
+            {lockType === "SVR" && visibleObjects["Top Rod"] && <SVRRods position={[15.25, 61.5, 0.5 + zOffset]} length={41} />}
+            {lockType === "SVR" && visibleObjects["Bottom Rod"] && <SVRRods position={[15.25, 21.5, 0.5 + zOffset]} length={39} />}
+            {visibleObjects["Chassis Cover"] && <Cover position={[15.25, 41, 0 + zOffset]} />}
+            {visibleObjects["Rail"] && <Rail position={[0, 0, -1 + zOffset]} scale={[40, 40, 40]} rotations={{ insert: [0, Math.PI / 2, Math.PI / 2], push: [Math.PI / 2, Math.PI / 2, 0], mounting: [0, Math.PI / 2, Math.PI / 2] }} />}
+            {visibleObjects["Trim"] && <ETTrim position={[15.25, 40.7875, 0.03 - zOffset]} />}
+            {visibleObjects["Screws"] && <Screws topPosition={[15.25, 43.5375, 0.025 + zOffset]} bottomPosition={[15.25, 38.45, 0.025 + zOffset]} thickness={parseFloat(thickness)} />}
+            {visibleObjects["Spindle"] && (
+              <>
+                <SquareSpindle position={[15.25, 39.7875, -0.125 - zOffset]} thickness={parseFloat(thickness)} />
+                <CrossSpindle position={[15.25, 39.7875, -0.125 - zOffset]} thickness={parseFloat(thickness)} />
+              </>
+            )}
+            <OrbitControls />
+          </Canvas>
+        </Suspense>
       </div>
     </div>
   );

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,22 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import { render, screen } from "@testing-library/react";
+import { Suspense } from "react";
+import App from "./App";
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+// Mock 3D libraries that require a real Canvas/WebGL context
+jest.mock("@react-three/fiber", () => ({
+  Canvas: ({ children }) => <div>{children}</div>,
+}));
+
+jest.mock("@react-three/drei", () => ({
+  OrbitControls: () => null,
+}));
+
+test("renders application title", () => {
+  render(
+    <Suspense fallback={null}>
+      <App />
+    </Suspense>
+  );
+  const titleElement = screen.getByText(/Sargent Thick Door Tool/i);
+  expect(titleElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- Lazy load heavy 3D components for faster initial page load
- Add CVR bottom case and reposition SVR/CVR cases with rods spanning from chassis to door edges
- Restyle layout with a smaller 3D viewer and update tests accordingly

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68960917d99483339e09b0ce31d4df55